### PR TITLE
fix: update ExampleTest to assert redirect to login

### DIFF
--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -14,6 +14,6 @@ class ExampleTest extends TestCase
     {
         $response = $this->get('/');
 
-        $response->assertStatus(200);
+        $response->assertRedirect('/login');
     }
 }


### PR DESCRIPTION
Changed the test to verify that the application redirects to the login page instead of returning a successful response. This aligns the test with the expected authentication flow.